### PR TITLE
Use Ksuid.BASE62_LENGTH with zfill instead of hardcoded 27

### DIFF
--- a/ksuid/ksuid.py
+++ b/ksuid/ksuid.py
@@ -68,7 +68,7 @@ class Ksuid:
     def __str__(self) -> str:
         """Creates a base62 string representation"""
 
-        return base62.encode(int.from_bytes(bytes(self), "big")).zfill(27)
+        return base62.encode(int.from_bytes(bytes(self), "big")).zfill(self.BASE62_LENGTH)
 
     def __repr__(self) -> str:
         return str(self)


### PR DESCRIPTION
Hi! First of all, thank you for this package!

This is a tiny PR that removes the hardcoded base62 length (27), replacing it with the class property `BASE62_LENGTH` (which will always be 27), which should help with readability and all that. 

My own purpose is to make it easier/cleaner to subclass `Ksuid` to use payloads of different lengths without unnecessarily redefining `__str__`.

```
class ShortKsuid(Ksuid):
    PAYLOAD_LENGTH_IN_BYTES = 8
    BYTES_LENGTH = Ksuid.TIMESTAMP_LENGTH_IN_BYTES + PAYLOAD_LENGTH_IN_BYTES
    BASE62_LENGTH = math.ceil(BYTES_LENGTH * 4 / 3)
```

(Obviously, the result is no longer a valid KSUID if the payload length is not 16 bytes, but they're useful for certain applications that don't need that much entropy. `BYTES_LENGTH` and `BASE62_LENGTH` could be redefined either as instance properties with a setter or with something like a metaclass, that way you wouldn't have to recompute them when defining a subclass, but that requires a few changes and is beyond the scope of this package.)